### PR TITLE
Use vendored (statically linked) openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ url = "^2.5"
 # weird enough that I'm bailing...
 # Actually, at the moment, there isn't; presumably we need
 # https://github.com/RustCrypto/RSA/issues/231
-openssl = "^0.10"
+openssl = { version = "^0.10", features = [ "vendored" ] }
 # This is really old, and pulls in an ancient version of syn, so it's
 # kinda heavy, but it's also apparently still the standard for doing its
 # job, so...


### PR DESCRIPTION
This prevents freebsd-rustdate from breaking if you try to run it again after upgrading your FreeBSD installation to one with a newer version of OpenSSL, letting you correctly use `freebsd-rustdate install` before and after reboot without needing a full rebuild of the tool itself, which might not be possible because the build toolchain might not have yet been upgraded post-upgrade but prior to the second invocation of `freebsd-rustdate install`.